### PR TITLE
Fix RandomForestClassifier ties in binary classification

### DIFF
--- a/src/orbital/translation/steps/trees/classifier.py
+++ b/src/orbital/translation/steps/trees/classifier.py
@@ -166,9 +166,18 @@ class TreeEnsembleClassifierTranslator(Translator):
                     apply_post_transform(total_score, post_transform),
                 )
 
+            # scikit-learn resolves a probability tie via ``argmax``, which
+            # returns the lowest class index (class 0). The ONNX leaf weights
+            # are stored as float32 (e.g. ``1 / n_estimators`` becomes
+            # ``0.10000000149...``), so a vote split that should sum to exactly
+            # 0.5 comes out marginally above it once promoted to double and
+            # would otherwise flip the tie to class 1. Requiring the score to
+            # exceed 0.5 by a small epsilon breaks ties toward class 0 to match
+            # scikit-learn while staying well below any genuine probability gap.
+            tie_epsilon = 1e-6
             label_expr = optimizer.fold_case(
                 ibis.cases(
-                    (total_score > 0.5, output_classlabels[1]),
+                    (total_score > 0.5 + tie_epsilon, output_classlabels[1]),
                     else_=output_classlabels[0],
                 )
             )

--- a/src/orbital/translation/steps/trees/classifier.py
+++ b/src/orbital/translation/steps/trees/classifier.py
@@ -30,6 +30,10 @@ class TreeEnsembleClassifierTranslator(Translator):
     the votes by the sum of all votes.
     """
 
+    # Margin by which a binary probability must exceed 0.5 to be counted as
+    # a win for class 1, used to break exact 0.5 ties toward class 0.
+    TIE_EPSILON = 1e-6
+
     def process(self) -> None:
         """Performs the translation and set the output variable."""
         # https://onnx.ai/onnx/operators/onnx_aionnxml_TreeEnsembleClassifier.html
@@ -174,10 +178,9 @@ class TreeEnsembleClassifierTranslator(Translator):
             # would otherwise flip the tie to class 1. Requiring the score to
             # exceed 0.5 by a small epsilon breaks ties toward class 0 to match
             # scikit-learn while staying well below any genuine probability gap.
-            tie_epsilon = 1e-6
             label_expr = optimizer.fold_case(
                 ibis.cases(
-                    (total_score > 0.5 + tie_epsilon, output_classlabels[1]),
+                    (total_score > 0.5 + self.TIE_EPSILON, output_classlabels[1]),
                     else_=output_classlabels[0],
                 )
             )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -278,9 +278,6 @@ class TestSingleStepPipelines:
             separate_trees=separate_trees,
         )
 
-    @pytest.mark.skip(
-        reason="SQL and sklearn predictions don't match - needs investigation"
-    )
     def test_random_forest_classifier_double_features(self):
         """Test RandomForestClassifier with all double features."""
         features = {


### PR DESCRIPTION
Fixes #58.

What was happening was that we were breaking ties (exact 0.5/0.5 probabilities) in accordance to what ONNX wanted it, but ONNX and scikit-learn disagreed on how to do that.

ONNX breaks ties up to class 1, and scikit-learn breaks ties down to class 0.

ONNX stores leaf weights as float32 (1/n_estimators becomes 0.10000000149…), so a vote split that should sum to exactly 0.5 comes out as 0.50000000745 once promoted to double, spilling genuine ties over the threshold.
