### PR TITLE
Apply ruff format to README code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,13 @@ from sklearn.preprocessing import StandardScaler
 
 pipeline = Pipeline(
     [
-        ("preprocess", ColumnTransformer([("scaler", StandardScaler(with_std=False), COLUMNS)],
-                                        remainder="passthrough")),
+        (
+            "preprocess",
+            ColumnTransformer(
+                [("scaler", StandardScaler(with_std=False), COLUMNS)],
+                remainder="passthrough",
+            ),
+        ),
         ("linear_regression", LinearRegression()),
     ]
 )
@@ -66,12 +71,15 @@ Convert the pipeline to orbital:
 import orbital
 import orbital.types
 
-orbital_pipeline = orbital.parse_pipeline(pipeline, features={
-    "sepal_length": orbital.types.DoubleColumnType(),
-    "sepal_width": orbital.types.DoubleColumnType(),
-    "petal_length": orbital.types.DoubleColumnType(),
-    "petal_width": orbital.types.DoubleColumnType(),
-})
+orbital_pipeline = orbital.parse_pipeline(
+    pipeline,
+    features={
+        "sepal_length": orbital.types.DoubleColumnType(),
+        "sepal_width": orbital.types.DoubleColumnType(),
+        "petal_length": orbital.types.DoubleColumnType(),
+        "petal_width": orbital.types.DoubleColumnType(),
+    },
+)
 ```
 
 You can print the pipeline to see the result:


### PR DESCRIPTION
The `ruff format --check` CI step now reformats the Python code blocks in `README.md` (Markdown code-block formatting), causing the formatter check to fail on unrelated PRs. This applies `ruff format` to `README.md` so the check passes again. No functional changes.