### PR TITLE
fix: negate the result when folding 0 - x

### DIFF
--- a/src/orbital/translation/optimizer.py
+++ b/src/orbital/translation/optimizer.py
@@ -277,7 +277,7 @@ class Optimizer:
             left_val = inputs[0].value if isinstance(inputs[0], Literal) else None
             right_val = inputs[1].value if isinstance(inputs[1], Literal) else None
             if left_val == 0:
-                return inputs[1].to_expr()
+                return -inputs[1].to_expr()
             elif right_val == 0:
                 return inputs[0].to_expr()
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -125,7 +125,13 @@ class TestOptimizerFold:
     def test_fold_zeros_subtract_left(self):
         expr = ibis.literal(0) - ibis.literal(5)
         result = self.optimizer.fold_zeros(expr)
-        assert result.op().value == 5
+        assert result.execute() == -5
+
+    def test_fold_zeros_subtract_left_column(self):
+        table = ibis.memtable({"value": [1.0, 2.0, 3.0]})
+        expr = ibis.literal(0) - table["value"]
+        result = self.optimizer.fold_zeros(expr)
+        assert result.execute().tolist() == pytest.approx([-1.0, -2.0, -3.0])
 
     def test_fold_zeros_subtract_right(self):
         expr = ibis.literal(5) - ibis.literal(0)


### PR DESCRIPTION
Closes #108

`fold_zeros` returned the right operand unchanged for a `Subtract` whose left operand is the literal `0`, so `0 - x` folded to `x` and the sign flip was dropped. The folded expression is now negated.

The existing `test_fold_zeros_subtract_left` only checked `result.op().value`, which is `5` either way, so it passed on the buggy code; it now asserts the computed value, and a column case is added alongside it. Both fail without the source change and pass with it (`tests/test_optimizer.py`: 2 failed / 18 passed before, 20 passed after).

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
