### PR TITLE
Support normalized operands in Add and Mul

### DIFF
--- a/src/orbital/translation/steps/add.py
+++ b/src/orbital/translation/steps/add.py
@@ -1,67 +1,67 @@
-"""Translate an Add operation to the equivalent query expression."""
-
-import typing
-
-import ibis
+"""Defines the translation step for the Add operation."""
 
 from ..translator import Translator
-from ..variables import NumericVariablesGroup, ValueVariablesGroup, VariablesGroup
+from ..variables import ValueVariablesGroup
 
 
 class AddTranslator(Translator):
     """Processes an Add node and updates the variables with the output expression.
 
-    Given the node to translate, the variables and constants available for
-    the translation context, generates a query expression that processes
-    the input variables and produces a new output variable that computes
-    based on the Add operation.
+    Both operands are treated symmetrically: each one can be a group of columns,
+    a single column, a constant scalar or a constant list of values.
+
+    When any of the two operands is a group of columns, the result is a group of
+    columns too and it borrows its column names from the first operand that is a
+    group, as those names end up being the names of the resulting SQL columns.
+    That group also dictates the width of the result: any other operand must
+    either provide exactly as many values, or a single value that is added to
+    every column of the group.
+
+    When neither operand is a group, both must be single values and the result
+    is a single column.
     """
 
     def process(self) -> None:
         """Performs the translation and set the output variable."""
         # https://onnx.ai/onnx/operators/onnx__Add.html
 
-        first_operand = self._variables.consume(self._inputs[0])
-        second_operand = self._variables.get_initializer_value(self._inputs[1])
-        if second_operand is None or not isinstance(second_operand, (list, tuple)):
-            raise NotImplementedError(
-                "Add: Second input (divisor) must be a constant list."
-            )
+        left_keys, left_values = self._variables.consume_operand_values(self.inputs[0])
+        right_keys, right_values = self._variables.consume_operand_values(
+            self.inputs[1]
+        )
 
-        type_check_var = first_operand
-        if isinstance(type_check_var, VariablesGroup):
-            type_check_var = next(iter(type_check_var.values()), None)
-        if not isinstance(type_check_var, ibis.expr.types.NumericValue):
-            raise ValueError("Add: The first operand must be a numeric value.")
-
-        add_values = list(second_operand)
-        if isinstance(first_operand, VariablesGroup):
-            first_operand = NumericVariablesGroup(first_operand)
-            struct_fields = list(first_operand.keys())
-            if len(add_values) != len(struct_fields):
-                # TODO: Implement dividing by a single value,
-                #       see Div implementation.
+        # The first operand that is a group dictates the width of the result
+        # and, at the very end, the names of the resulting columns.
+        keys = left_keys if left_keys is not None else right_keys
+        if keys is None:
+            # Simple case, no columns group involved, so we just add the two values.
+            if len(left_values) != 1 or len(right_values) != 1:
                 raise ValueError(
-                    "When the first operand is a group of columns, the second operand must contain the same number of values"
+                    "Add: when no operand is a group of columns, each operand must contain only one value."
                 )
             self.set_output(
-                ValueVariablesGroup(
-                    {
-                        field: (
-                            self._optimizer.fold_operations(
-                                first_operand[field] + add_values[i]
-                            )
-                        )
-                        for i, field in enumerate(struct_fields)
-                    }
-                )
+                self._optimizer.fold_operations(left_values[0] + right_values[0])
             )
-        else:
-            if len(add_values) != 1:
+            return
+
+        for values in (left_values, right_values):
+            if len(values) not in (1, len(keys)):
                 raise ValueError(
-                    "When the first operand is a single column, the second operand must contain exactly 1 value"
+                    "Add: the number of values of each operand must match the number of columns of the resulting group."
                 )
-            first_operand = typing.cast(ibis.expr.types.NumericValue, first_operand)
-            self.set_output(
-                self._optimizer.fold_operations(first_operand + add_values[0])
+        # A single value is shared by all columns of the resulting group.
+        if len(left_values) == 1:
+            left_values = left_values * len(keys)
+        if len(right_values) == 1:
+            right_values = right_values * len(keys)
+
+        self.set_output(
+            ValueVariablesGroup(
+                {
+                    key: self._optimizer.fold_operations(left_value + right_value)
+                    for key, left_value, right_value in zip(
+                        keys, left_values, right_values
+                    )
+                }
             )
+        )

--- a/src/orbital/translation/steps/matmul.py
+++ b/src/orbital/translation/steps/matmul.py
@@ -1,4 +1,4 @@
-"""Implementation of the LabelEncoder operator."""
+"""Implementation of the MatMul operator."""
 
 import typing
 
@@ -41,7 +41,7 @@ class MatMulTranslator(Translator):
         coef = self._variables.get_initializer_value(self.inputs[1])
         if coef is None or not isinstance(coef, (list, tuple)):
             raise NotImplementedError(
-                "MatMul: Second input (divisor) must be a constant list."
+                "MatMul: Second input (coefficient tensor) must be a constant list."
             )
         coef_type_check = coef[0]
         if not isinstance(coef_type_check, (int, float)):

--- a/src/orbital/translation/steps/mul.py
+++ b/src/orbital/translation/steps/mul.py
@@ -1,67 +1,67 @@
-"""Translate an Mul operation to the equivalent query expression."""
-
-import typing
-
-import ibis
+"""Defines the translation step for the Mul operation."""
 
 from ..translator import Translator
-from ..variables import NumericVariablesGroup, ValueVariablesGroup, VariablesGroup
+from ..variables import ValueVariablesGroup
 
 
 class MulTranslator(Translator):
-    """Processes an Mul node and updates the variables with the output expression.
+    """Processes a Mul node and updates the variables with the output expression.
 
-    Given the node to translate, the variables and constants available for
-    the translation context, generates a query expression that processes
-    the input variables and produces a new output variable that computes
-    based on the Mul operation.
+    Both operands are treated symmetrically: each one can be a group of columns,
+    a single column, a constant scalar or a constant list of values.
+
+    When any of the two operands is a group of columns, the result is a group of
+    columns too and it borrows its column names from the first operand that is a
+    group, as those names end up being the names of the resulting SQL columns.
+    That group also dictates the width of the result: any other operand must
+    either provide exactly as many values, or a single value that is multiplied
+    by every column of the group.
+
+    When neither operand is a group, both must be single values and the result
+    is a single column.
     """
 
     def process(self) -> None:
         """Performs the translation and set the output variable."""
         # https://onnx.ai/onnx/operators/onnx__Mul.html
 
-        first_operand = self._variables.consume(self._inputs[0])
-        second_operand = self._variables.get_initializer_value(self._inputs[1])
-        if second_operand is None or not isinstance(second_operand, (list, tuple)):
-            raise NotImplementedError(
-                "Mul: Second input (divisor) must be a constant list."
-            )
+        left_keys, left_values = self._variables.consume_operand_values(self.inputs[0])
+        right_keys, right_values = self._variables.consume_operand_values(
+            self.inputs[1]
+        )
 
-        type_check_var = first_operand
-        if isinstance(type_check_var, VariablesGroup):
-            type_check_var = next(iter(type_check_var.values()), None)
-        if not isinstance(type_check_var, ibis.expr.types.NumericValue):
-            raise ValueError("Mul: The first operand must be a numeric value.")
-
-        add_values = list(second_operand)
-        if isinstance(first_operand, VariablesGroup):
-            first_operand = NumericVariablesGroup(first_operand)
-            struct_fields = list(first_operand.keys())
-            if len(add_values) != len(struct_fields):
-                # TODO: Implement dividing by a single value,
-                #       see Div implementation.
+        # The first operand that is a group dictates the width of the result
+        # and, at the very end, the names of the resulting columns.
+        keys = left_keys if left_keys is not None else right_keys
+        if keys is None:
+            # Simple case, no columns group involved, so we just multiply the values.
+            if len(left_values) != 1 or len(right_values) != 1:
                 raise ValueError(
-                    "When the first operand is a group of columns, the second operand must contain the same number of values"
+                    "Mul: when no operand is a group of columns, each operand must contain only one value."
                 )
             self.set_output(
-                ValueVariablesGroup(
-                    {
-                        field: (
-                            self._optimizer.fold_operations(
-                                first_operand[field] * add_values[i]
-                            )
-                        )
-                        for i, field in enumerate(struct_fields)
-                    }
-                )
+                self._optimizer.fold_operations(left_values[0] * right_values[0])
             )
-        else:
-            if len(add_values) != 1:
+            return
+
+        for values in (left_values, right_values):
+            if len(values) not in (1, len(keys)):
                 raise ValueError(
-                    "When the first operand is a single column, the second operand must contain exactly 1 value"
+                    "Mul: the number of values of each operand must match the number of columns of the resulting group."
                 )
-            first_operand = typing.cast(ibis.expr.types.NumericValue, first_operand)
-            self.set_output(
-                self._optimizer.fold_operations(first_operand * add_values[0])
+        # A single value is shared by all columns of the resulting group.
+        if len(left_values) == 1:
+            left_values = left_values * len(keys)
+        if len(right_values) == 1:
+            right_values = right_values * len(keys)
+
+        self.set_output(
+            ValueVariablesGroup(
+                {
+                    key: self._optimizer.fold_operations(left_value * right_value)
+                    for key, left_value, right_value in zip(
+                        keys, left_values, right_values
+                    )
+                }
             )
+        )

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -619,11 +619,11 @@ class TestAddTranslator:
             table, model.node[0], variables, self.optimizer, TranslationOptions()
         )
 
-        with pytest.raises(ValueError, match="first operand must be a numeric value"):
+        with pytest.raises(ValueError, match="operands must be numeric values"):
             translator.process()
 
-    def test_add_mismatched_column_count(self):
-        """Test AddTranslator raises error when column count doesn't match."""
+    def test_add_group_columns_broadcast_single_value(self):
+        """Test AddTranslator broadcasts a single value over grouped columns."""
         table = ibis.memtable(
             {
                 "col_a": [1.0, 2.0, 3.0],
@@ -632,9 +632,9 @@ class TestAddTranslator:
         )
         model = onnx.parser.parse_graph("""
             agraph (float[N] input) => (float[N] output)
-            <float[1] add_values = {5.0}>
+            <float[1] add_value = {5.0}>
             {
-                output = Add(input, add_values)
+                output = Add(input, add_value)
             }
         """)
 
@@ -650,8 +650,15 @@ class TestAddTranslator:
             table, model.node[0], variables, self.optimizer, TranslationOptions()
         )
 
-        with pytest.raises(ValueError, match="same number of values"):
-            translator.process()
+        translator.process()
+
+        result = variables.peek_variable("output")
+        assert isinstance(result, ValueVariablesGroup)
+        assert list(result.keys()) == ["col_a", "col_b"]
+
+        backend = ibis.duckdb.connect()
+        assert list(backend.execute(result["col_a"])) == [6.0, 7.0, 8.0]
+        assert list(backend.execute(result["col_b"])) == [15.0, 25.0, 35.0]
 
     def test_add_single_column_requires_single_value(self):
         """Test AddTranslator raises error when single column given multiple values."""
@@ -670,15 +677,15 @@ class TestAddTranslator:
             table, model.node[0], variables, self.optimizer, TranslationOptions()
         )
 
-        with pytest.raises(ValueError, match="must contain exactly 1 value"):
+        with pytest.raises(ValueError, match="must contain only one value"):
             translator.process()
 
-    def test_add_second_operand_not_constant(self):
-        """Test AddTranslator raises error when second operand is not a constant."""
+    def test_add_column_plus_computed_column(self):
+        """Test AddTranslator adds a column computed by a previous node."""
         table = ibis.memtable(
             {
                 "input": [1.0, 2.0, 3.0],
-                "other": [5.0, 5.0, 5.0],
+                "other": [5.0, 6.0, 7.0],
             }
         )
         model = onnx.parser.parse_graph("""
@@ -693,7 +700,182 @@ class TestAddTranslator:
             table, model.node[0], variables, self.optimizer, TranslationOptions()
         )
 
-        with pytest.raises(NotImplementedError, match="must be a constant list"):
+        translator.process()
+
+        result = variables.peek_variable("output")
+
+        # The second operand must be consumed, or it would leak into the results.
+        assert "other" not in variables
+
+        backend = ibis.duckdb.connect()
+        assert list(backend.execute(result)) == [6.0, 8.0, 10.0]
+
+    def test_add_constant_plus_column(self):
+        """Test AddTranslator adds a column to a scalar constant."""
+        table = ibis.memtable({"input": [1.0, 2.0, 3.0]})
+        model = onnx.parser.parse_graph("""
+            agraph (float[N] input) => (float[N] output)
+            <float add_value = {5.0}>
+            {
+                output = Add(add_value, input)
+            }
+        """)
+
+        variables = GraphVariables(table, model)
+        translator = AddTranslator(
+            table, model.node[0], variables, self.optimizer, TranslationOptions()
+        )
+        translator.process()
+
+        result = variables.peek_variable("output")
+
+        backend = ibis.duckdb.connect()
+        assert list(backend.execute(result)) == [6.0, 7.0, 8.0]
+
+    def test_add_constant_plus_group_columns(self):
+        """Test AddTranslator adds a scalar constant to grouped columns."""
+        table = ibis.memtable({"col_a": [1.0, 2.0], "col_b": [10.0, 20.0]})
+        model = onnx.parser.parse_graph("""
+            agraph (float[N] input) => (float[N] output)
+            <float add_value = {5.0}>
+            {
+                output = Add(add_value, input)
+            }
+        """)
+
+        variables = GraphVariables(ibis.memtable({"input": [1.0]}), model)
+        variables["input"] = NumericVariablesGroup(
+            {
+                "col_a": table["col_a"],
+                "col_b": table["col_b"],
+            }
+        )
+
+        translator = AddTranslator(
+            table, model.node[0], variables, self.optimizer, TranslationOptions()
+        )
+        translator.process()
+
+        result = variables.peek_variable("output")
+        assert isinstance(result, ValueVariablesGroup)
+        assert list(result.keys()) == ["col_a", "col_b"]
+
+        backend = ibis.duckdb.connect()
+        assert list(backend.execute(result["col_a"])) == [6.0, 7.0]
+        assert list(backend.execute(result["col_b"])) == [15.0, 25.0]
+
+    def test_add_group_columns_plus_group_columns(self):
+        """Test AddTranslator adds groups and keeps the first group's names."""
+        table = ibis.memtable(
+            {
+                "input": [1.0, 1.0],
+                "other": [1.0, 1.0],
+                "left_a": [1.0, 2.0],
+                "left_b": [10.0, 20.0],
+                "right_a": [3.0, 4.0],
+                "right_b": [30.0, 40.0],
+            }
+        )
+        model = onnx.parser.parse_graph("""
+            agraph (float[N] input, float[N] other) => (float[N] output) {
+                output = Add(input, other)
+            }
+        """)
+
+        variables = GraphVariables(table, model)
+        variables["input"] = NumericVariablesGroup(
+            {
+                "col_a": table["left_a"],
+                "col_b": table["left_b"],
+            }
+        )
+        variables["other"] = NumericVariablesGroup(
+            {
+                "other_a": table["right_a"],
+                "other_b": table["right_b"],
+            }
+        )
+
+        translator = AddTranslator(
+            table, model.node[0], variables, self.optimizer, TranslationOptions()
+        )
+        translator.process()
+
+        result = variables.peek_variable("output")
+        assert isinstance(result, ValueVariablesGroup)
+        assert list(result.keys()) == ["col_a", "col_b"]
+
+        backend = ibis.duckdb.connect()
+        assert list(backend.execute(result["col_a"])) == [4.0, 6.0]
+        assert list(backend.execute(result["col_b"])) == [40.0, 60.0]
+
+    def test_add_group_columns_plus_computed_column(self):
+        """Test AddTranslator broadcasts a computed column over a group."""
+        table = ibis.memtable(
+            {
+                "input": [1.0, 1.0],
+                "other": [2.0, 4.0],
+                "col_a": [10.0, 20.0],
+                "col_b": [100.0, 200.0],
+            }
+        )
+        model = onnx.parser.parse_graph("""
+            agraph (float[N] input, float[N] other) => (float[N] output) {
+                output = Add(input, other)
+            }
+        """)
+
+        variables = GraphVariables(table, model)
+        variables["input"] = NumericVariablesGroup(
+            {
+                "col_a": table["col_a"],
+                "col_b": table["col_b"],
+            }
+        )
+
+        translator = AddTranslator(
+            table, model.node[0], variables, self.optimizer, TranslationOptions()
+        )
+        translator.process()
+
+        result = variables.peek_variable("output")
+        assert isinstance(result, ValueVariablesGroup)
+        assert list(result.keys()) == ["col_a", "col_b"]
+        assert "other" not in variables
+
+        backend = ibis.duckdb.connect()
+        assert list(backend.execute(result["col_a"])) == [12.0, 24.0]
+        assert list(backend.execute(result["col_b"])) == [102.0, 204.0]
+
+    def test_add_mismatched_column_count(self):
+        """Test AddTranslator raises error when operand widths do not match."""
+        table = ibis.memtable(
+            {
+                "col_a": [1.0, 2.0, 3.0],
+                "col_b": [10.0, 20.0, 30.0],
+            }
+        )
+        model = onnx.parser.parse_graph("""
+            agraph (float[N] input) => (float[N] output)
+            <float[3] add_values = {5.0, 10.0, 15.0}>
+            {
+                output = Add(input, add_values)
+            }
+        """)
+
+        variables = GraphVariables(ibis.memtable({"input": [1.0]}), model)
+        variables["input"] = NumericVariablesGroup(
+            {
+                "col_a": table["col_a"],
+                "col_b": table["col_b"],
+            }
+        )
+
+        translator = AddTranslator(
+            table, model.node[0], variables, self.optimizer, TranslationOptions()
+        )
+
+        with pytest.raises(ValueError, match="must match the number of columns"):
             translator.process()
 
 
@@ -1065,11 +1247,11 @@ class TestMulTranslator:
             table, model.node[0], variables, self.optimizer, TranslationOptions()
         )
 
-        with pytest.raises(ValueError, match="first operand must be a numeric value"):
+        with pytest.raises(ValueError, match="operands must be numeric values"):
             translator.process()
 
-    def test_mul_mismatched_column_count(self):
-        """Test MulTranslator raises error when column count doesn't match."""
+    def test_mul_group_columns_broadcast_single_value(self):
+        """Test MulTranslator broadcasts a single value over grouped columns."""
         table = ibis.memtable(
             {
                 "col_a": [1.0, 2.0, 3.0],
@@ -1078,9 +1260,9 @@ class TestMulTranslator:
         )
         model = onnx.parser.parse_graph("""
             agraph (float[N] input) => (float[N] output)
-            <float[1] mul_values = {5.0}>
+            <float[1] mul_value = {5.0}>
             {
-                output = Mul(input, mul_values)
+                output = Mul(input, mul_value)
             }
         """)
 
@@ -1096,8 +1278,15 @@ class TestMulTranslator:
             table, model.node[0], variables, self.optimizer, TranslationOptions()
         )
 
-        with pytest.raises(ValueError, match="same number of values"):
-            translator.process()
+        translator.process()
+
+        result = variables.peek_variable("output")
+        assert isinstance(result, ValueVariablesGroup)
+        assert list(result.keys()) == ["col_a", "col_b"]
+
+        backend = ibis.duckdb.connect()
+        assert list(backend.execute(result["col_a"])) == [5.0, 10.0, 15.0]
+        assert list(backend.execute(result["col_b"])) == [50.0, 100.0, 150.0]
 
     def test_mul_single_column_requires_single_value(self):
         """Test MulTranslator raises error when single column given multiple values."""
@@ -1116,15 +1305,15 @@ class TestMulTranslator:
             table, model.node[0], variables, self.optimizer, TranslationOptions()
         )
 
-        with pytest.raises(ValueError, match="must contain exactly 1 value"):
+        with pytest.raises(ValueError, match="must contain only one value"):
             translator.process()
 
-    def test_mul_second_operand_not_constant(self):
-        """Test MulTranslator raises error when second operand is not a constant."""
+    def test_mul_column_by_computed_column(self):
+        """Test MulTranslator multiplies by a column computed by a previous node."""
         table = ibis.memtable(
             {
                 "input": [1.0, 2.0, 3.0],
-                "other": [5.0, 5.0, 5.0],
+                "other": [5.0, 6.0, 7.0],
             }
         )
         model = onnx.parser.parse_graph("""
@@ -1139,7 +1328,182 @@ class TestMulTranslator:
             table, model.node[0], variables, self.optimizer, TranslationOptions()
         )
 
-        with pytest.raises(NotImplementedError, match="must be a constant list"):
+        translator.process()
+
+        result = variables.peek_variable("output")
+
+        # The second operand must be consumed, or it would leak into the results.
+        assert "other" not in variables
+
+        backend = ibis.duckdb.connect()
+        assert list(backend.execute(result)) == [5.0, 12.0, 21.0]
+
+    def test_mul_constant_by_column(self):
+        """Test MulTranslator multiplies a scalar constant by a column."""
+        table = ibis.memtable({"input": [1.0, 2.0, 3.0]})
+        model = onnx.parser.parse_graph("""
+            agraph (float[N] input) => (float[N] output)
+            <float mul_value = {5.0}>
+            {
+                output = Mul(mul_value, input)
+            }
+        """)
+
+        variables = GraphVariables(table, model)
+        translator = MulTranslator(
+            table, model.node[0], variables, self.optimizer, TranslationOptions()
+        )
+        translator.process()
+
+        result = variables.peek_variable("output")
+
+        backend = ibis.duckdb.connect()
+        assert list(backend.execute(result)) == [5.0, 10.0, 15.0]
+
+    def test_mul_constant_by_group_columns(self):
+        """Test MulTranslator multiplies a scalar constant by grouped columns."""
+        table = ibis.memtable({"col_a": [1.0, 2.0], "col_b": [10.0, 20.0]})
+        model = onnx.parser.parse_graph("""
+            agraph (float[N] input) => (float[N] output)
+            <float mul_value = {5.0}>
+            {
+                output = Mul(mul_value, input)
+            }
+        """)
+
+        variables = GraphVariables(ibis.memtable({"input": [1.0]}), model)
+        variables["input"] = NumericVariablesGroup(
+            {
+                "col_a": table["col_a"],
+                "col_b": table["col_b"],
+            }
+        )
+
+        translator = MulTranslator(
+            table, model.node[0], variables, self.optimizer, TranslationOptions()
+        )
+        translator.process()
+
+        result = variables.peek_variable("output")
+        assert isinstance(result, ValueVariablesGroup)
+        assert list(result.keys()) == ["col_a", "col_b"]
+
+        backend = ibis.duckdb.connect()
+        assert list(backend.execute(result["col_a"])) == [5.0, 10.0]
+        assert list(backend.execute(result["col_b"])) == [50.0, 100.0]
+
+    def test_mul_group_columns_by_group_columns(self):
+        """Test MulTranslator multiplies groups and keeps the first group's names."""
+        table = ibis.memtable(
+            {
+                "input": [1.0, 1.0],
+                "other": [1.0, 1.0],
+                "left_a": [1.0, 2.0],
+                "left_b": [10.0, 20.0],
+                "right_a": [3.0, 4.0],
+                "right_b": [30.0, 40.0],
+            }
+        )
+        model = onnx.parser.parse_graph("""
+            agraph (float[N] input, float[N] other) => (float[N] output) {
+                output = Mul(input, other)
+            }
+        """)
+
+        variables = GraphVariables(table, model)
+        variables["input"] = NumericVariablesGroup(
+            {
+                "col_a": table["left_a"],
+                "col_b": table["left_b"],
+            }
+        )
+        variables["other"] = NumericVariablesGroup(
+            {
+                "other_a": table["right_a"],
+                "other_b": table["right_b"],
+            }
+        )
+
+        translator = MulTranslator(
+            table, model.node[0], variables, self.optimizer, TranslationOptions()
+        )
+        translator.process()
+
+        result = variables.peek_variable("output")
+        assert isinstance(result, ValueVariablesGroup)
+        assert list(result.keys()) == ["col_a", "col_b"]
+
+        backend = ibis.duckdb.connect()
+        assert list(backend.execute(result["col_a"])) == [3.0, 8.0]
+        assert list(backend.execute(result["col_b"])) == [300.0, 800.0]
+
+    def test_mul_group_columns_by_computed_column(self):
+        """Test MulTranslator broadcasts a computed column over a group."""
+        table = ibis.memtable(
+            {
+                "input": [1.0, 1.0],
+                "other": [2.0, 4.0],
+                "col_a": [10.0, 20.0],
+                "col_b": [100.0, 200.0],
+            }
+        )
+        model = onnx.parser.parse_graph("""
+            agraph (float[N] input, float[N] other) => (float[N] output) {
+                output = Mul(input, other)
+            }
+        """)
+
+        variables = GraphVariables(table, model)
+        variables["input"] = NumericVariablesGroup(
+            {
+                "col_a": table["col_a"],
+                "col_b": table["col_b"],
+            }
+        )
+
+        translator = MulTranslator(
+            table, model.node[0], variables, self.optimizer, TranslationOptions()
+        )
+        translator.process()
+
+        result = variables.peek_variable("output")
+        assert isinstance(result, ValueVariablesGroup)
+        assert list(result.keys()) == ["col_a", "col_b"]
+        assert "other" not in variables
+
+        backend = ibis.duckdb.connect()
+        assert list(backend.execute(result["col_a"])) == [20.0, 80.0]
+        assert list(backend.execute(result["col_b"])) == [200.0, 800.0]
+
+    def test_mul_mismatched_column_count(self):
+        """Test MulTranslator raises error when operand widths do not match."""
+        table = ibis.memtable(
+            {
+                "col_a": [1.0, 2.0, 3.0],
+                "col_b": [10.0, 20.0, 30.0],
+            }
+        )
+        model = onnx.parser.parse_graph("""
+            agraph (float[N] input) => (float[N] output)
+            <float[3] mul_values = {5.0, 10.0, 15.0}>
+            {
+                output = Mul(input, mul_values)
+            }
+        """)
+
+        variables = GraphVariables(ibis.memtable({"input": [1.0]}), model)
+        variables["input"] = NumericVariablesGroup(
+            {
+                "col_a": table["col_a"],
+                "col_b": table["col_b"],
+            }
+        )
+
+        translator = MulTranslator(
+            table, model.node[0], variables, self.optimizer, TranslationOptions()
+        )
+
+        with pytest.raises(ValueError, match="must match the number of columns"):
             translator.process()
 
 


### PR DESCRIPTION
## Summary

- route Add and Mul operands through `GraphVariables.consume_operand_values()`, matching Div and Sub
- support scalar, list, computed-column, and grouped-column operands with width-one broadcasting
- add executed-value regression coverage for the complete operand matrix and retain true width/type failures
- correct the MatMul module and coefficient-tensor wording

Closes #126.

## Validation

- `uv run pytest` — 364 passed, 29 skipped
- `uv run bash examples/test_examples.sh` — all 11 examples passed (Git Bash used because `.sh` is not directly executable on Windows)
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — 65 files already formatted
- `uv run mypy` — no issues in 47 source files
- `uv run pre-commit run -a` — Ruff hooks passed; the MyPy hook could not launch on native Windows because it hard-codes `.venv/bin/mypy`, so the same MyPy command was run directly above

AI assistance: Codex helped analyze the existing Div/Sub pattern, implement the change, and prepare tests. The full diff was independently reviewed and verified with the checks listed above.